### PR TITLE
Handling issue with tf2 circular dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(tf2_2d)
 
 add_compile_options(-std=c++14)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ add_compile_options(-Werror)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   tf2
-  tf2_geometry_msgs  # Included to solve a build issue caused by https://github.com/ros/geometry2/issues/275
+  tf2_geometry_msgs
 )
 find_package(Eigen3 REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ add_compile_options(-Werror)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   tf2
+  tf2_geometry_msgs  # Included to solve a build issue caused by https://github.com/ros/geometry2/issues/275
 )
 find_package(Eigen3 REQUIRED)
 
@@ -17,6 +18,7 @@ catkin_package(
   CATKIN_DEPENDS
     roscpp
     tf2
+    tf2_geometry_msgs
   DEPENDS
     EIGEN3
 )

--- a/include/tf2_2d/tf2_2d.h
+++ b/include/tf2_2d/tf2_2d.h
@@ -52,6 +52,7 @@
 #include <tf2_2d/rotation.h>
 #include <tf2_2d/transform.h>
 #include <tf2_2d/vector2.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 #include <boost/array.hpp>
 #include <Eigen/Core>

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
   <depend>eigen</depend>
   <depend>roscpp</depend>
   <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
 
   <test_depend>roslint</test_depend>
 </package>


### PR DESCRIPTION
See this:

https://build.ros.org/job/Mdev__tf2_2d__ubuntu_bionic_amd64/1/consoleFull

and this:

https://github.com/ros/geometry2/issues/275

EDIT: and this:

https://build.ros.org/job/Npr_db__tf2_2d__debian_buster_amd64/1/consoleFull
https://answers.ros.org/question/361001/how-to-fix-unstable-build-on-buildfarm-for-noetic-because-of-cmp0048/

