### PR TITLE
Exporting boost dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,5 +93,8 @@ if(BUILD_TESTING)
   )
 endif()
 
-ament_export_dependencies(Boost)
+ament_export_dependencies(
+  Boost
+  Eigen3
+)
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,4 +93,5 @@ if(BUILD_TESTING)
   )
 endif()
 
+ament_export_dependencies(Boost)
 ament_package()


### PR DESCRIPTION
When building a package that has a `tf2_2d` dependency, `CMake` complains about a missing `Boost` dependency, even if the package doesn't use Boost. This looks to be caused by `tf2_2d`, which uses `boost::array`.

```
CMake Error at CMakeLists.txt:20 (add_library):
  Target "<whatever>" links to target "Boost::boost" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?
```

I think this should fix the issue.