### PR TITLE
Testing a rather ugly solution for Eigen dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,8 @@ catkin_package(
     roscpp
     tf2
     tf2_geometry_msgs
-  DEPENDS
-    EIGEN3
+  CFG_EXTRAS
+    ${PROJECT_NAME}-extras.cmake
 )
 
 ###########

--- a/cmake/tf2_2d-extras.cmake
+++ b/cmake/tf2_2d-extras.cmake
@@ -1,0 +1,4 @@
+find_package(Eigen3 REQUIRED)
+include_directories(SYSTEM
+  ${EIGEN3_INCLUDE_DIRS}
+)


### PR DESCRIPTION
Testing a rather ugly solution Eigen dependencies.

In Ubuntu 24.04, some compiler warnings occur when using Eigen objects. Using -wall will then cause the build to fail.
```
/usr/include/eigen3/Eigen/src/Core/arch/AVX/PacketMath.h: In function ‘Eigen::internal::Packet8bf Eigen::internal::F32ToBf16(const Packet8f&)’:
/usr/include/eigen3/Eigen/src/Core/arch/AVX/PacketMath.h:1275:13: error: unused variable ‘r’ [-Werror=unused-variable]
 1275 |   Packet8bf r;
      |             ^
cc1plus: all warnings being treated as errors
```

The ideal solution would be for Eigen to fix the compile warning.

The second-best solution would be to import Eigen as a "system" dependency. This tells the compile to ignore build warnings that arise from inside the library. When using Eigen _within_ a package, this is easy enough to do:
```
include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS})
```

However, when you create a shared library that includes Eigen in the headers, then packages that use this package also need to compile with the Eigen headers. The ROS1 system for this is to add a `DEPENDS Eigen3` clause to the `catkin_package()` call in CmakeLists.txt. But the ROS1 system does not provide a mechanism for exporting a build dependency as "system" include rather than a "normal" include. Thus far, I have been unable to find a clean way to export Eigen to dependent packages correctly.

This PR is the first way I've found that works, and it is decidedly incorrect. In order to get Eigen included as a "system" header, I've created a cmake file that calls `find_package(Eigen3)` plus `include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS})`. Whenever another package depends on tf2_2d, this cmake file will get sourced, the Eigen library will be located, and Eigen will be added to the package's global include directory list with the "system" property attached.

I'm hoping someone can provide an alternative option? Or let me know just how bad of an idea this is.